### PR TITLE
cleanup: remove @VROOT references from v.mod . Ignore generated files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
         cd example/        
         time ../../v/v run main.v
     - name: Results
-      run: |
-        ls -lart example/*
+      run: ls -lart example/*
+    - name: demo.json
+      run: cat example/demo.json
 
   macos:
     runs-on: macos-latest
@@ -36,8 +37,9 @@ jobs:
         cd example
         time ../../v/v run main.v
     - name: Results
-      run: |        
-        ls -lart example/*
+      run: ls -lart example/*
+    - name: demo.json
+      run: cat example/demo.json
 
   windows-msvc:
     runs-on: windows-latest
@@ -56,6 +58,7 @@ jobs:
         cd example
         ..\..\v\v.exe run main.v
     - name: Results
-      run: |
-        dir example\
+      run: dir example\
+    - name: demo.json
+      run: type example/demo.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build V
+      run: |
+        git clone --depth 1 https://github.com/vlang/v ../v
+        cd ../v
+        make
+    - name: Build example
+      run: |
+        cp -rf ../vast ../v/vlib/vast
+        cd example/        
+        time ../../v/v run main.v
+    - name: Results
+      run: |
+        ls -lart example/*
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build V
+      run: |
+        git clone --depth 1 https://github.com/vlang/v ../v
+        cd ../v
+        make
+    - name: Build example
+      run: |
+        cp -rf ../vast ../v/vlib/vast
+        cd example
+        time ../../v/v run main.v
+    - name: Results
+      run: |        
+        ls -lart example/*
+
+  windows-msvc:
+    runs-on: windows-latest
+    env:
+        VFLAGS: -cc msvc
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build V
+      run: |
+        git clone --depth 1 https://github.com/vlang/v ..\v
+        cd ..\v
+        .\make.bat -msvc
+    - name: Build example
+      run: |
+        xcopy ..\vast ..\v\vlib\vast /e /i /h
+        cd example
+        ..\..\v\v.exe run main.v
+    - name: Results
+      run: |
+        dir example\
+

--- a/cjson.v
+++ b/cjson.v
@@ -2,6 +2,9 @@ module vast
 
 import json
 
+struct UseJson { x int }
+fn suppress_json_warning(){ json.encode(UseJson{}) }
+
 // struct C.cJSON {}
 
 fn C.cJSON_CreateObject() &C.cJSON

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+main
+demo.json

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,3 @@
-#flag -I @VROOT/thirdparty/cJSON
-#flag @VROOT/thirdparty/cJSON/cJSON.o
-#include "cJSON.h"
-
 Module {
 	name: 'vast',
 	description: 'A simple tool for vlang, generate v source file to  AST json file',


### PR DESCRIPTION
This PR does some cleanup:

1) Removes `@VROOT` from `v.mod` - `@VROOT` is parsed only inside `#flag`
rows in `.v` files. It has no meaning in `v.mod` files.

2) Ignore generated `example/main` executable. 

3) Ignore the generated `example/demo.json` too.

4) suppresses an unused warning about the json module.